### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "homepage": "https://github.com/sbine/nova-route-viewer",
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^11.0 || ^12.0",
+        "php": "^8.3",
+        "laravel/framework": "^11.0 || ^12.0 || ^13.0",
         "laravel/nova": "^4.0 || ^5.0"
     },
     "repositories": [


### PR DESCRIPTION
## Summary
- Update `laravel/framework` constraint to include `^13.0`
- Bump minimum PHP version to `^8.3`

## Test plan
- [ ] Verify the package installs correctly in a Laravel 12 project
- [ ] Verify the package installs correctly in a Laravel 13 project